### PR TITLE
Revert "Revert "zygote: Allow device to append extra whitelisted paths""

### DIFF
--- a/core/jni/fd_utils-inl-extra.h
+++ b/core/jni/fd_utils-inl-extra.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+#define PATH_WHITELIST_EXTRA_H \
+    "/proc/apid", \
+    "/proc/aprf",
+*/
+
+// Overload this file in your device specific config if you need
+// to add extra whitelisted paths.
+// WARNING: Only use this if necessary. Custom inits should be
+// checked for leaked file descriptors before even considering
+// this.
+// In order to add your files, copy the whole file (don't forget the copyright notice!),
+// uncomment the #define above and change the paths inside to match your requirements

--- a/core/jni/fd_utils-inl.h
+++ b/core/jni/fd_utils-inl.h
@@ -35,6 +35,8 @@
 #include "JNIHelp.h"
 #include "ScopedPrimitiveArray.h"
 
+#include <fd_utils-inl-extra.h>
+
 // Whitelist of open paths that the zygote is allowed to keep open.
 //
 // In addition to the paths listed here, all files ending with
@@ -57,6 +59,9 @@ static const char* kPathWhitelist[] = {
   "/dev/ion",
   "/dev/dri/renderD129", // Fixes b/31172436
   "/system/framework/org.cyanogenmod.platform-res.apk",
+#ifdef PATH_WHITELIST_EXTRA_H
+PATH_WHITELIST_EXTRA_H
+#endif
 };
 
 static const char* kFdPath = "/proc/self/fd";


### PR DESCRIPTION
This reverts commit 14c4c0429aec19e2cd2ae1a6e6897d485fab0e31.

Since this was approved for cm-13.0, it needs put back in here.

Change-Id: Ibbffdced9ee86370821e4c8766a8dc9fe6a6af99